### PR TITLE
feat: add persistent notes tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,11 @@
 
 /************ Tabs ************/
 const tabButtons = document.querySelectorAll('.tab');
-const pages = { dpr: document.getElementById('page-dpr'), init: document.getElementById('page-init') };
+const pages = {
+  dpr: document.getElementById('page-dpr'),
+  init: document.getElementById('page-init'),
+  notes: document.getElementById('page-notes')
+};
 tabButtons.forEach(btn=>{
   btn.addEventListener('click', ()=>{
     tabButtons.forEach(x=>x.classList.remove('active'));
@@ -900,3 +904,94 @@ document.getElementById('autoSort').addEventListener('change', ()=>{ if (documen
 
 // initial render for tracker
 renderInit();
+
+/************ Notes ************/
+const notesList = document.getElementById('notesList');
+const addNoteBtn = document.getElementById('addNote');
+const clearNotesBtn = document.getElementById('clearNotes');
+let draggingNote = null;
+
+function autoResize(ta){
+  ta.style.height = 'auto';
+  ta.style.height = ta.scrollHeight + 'px';
+}
+
+function saveNotes(){
+  const notes = Array.from(notesList.querySelectorAll('.note-text')).map(t=>t.value);
+  localStorage.setItem('notes', JSON.stringify(notes));
+}
+
+function createNote(text=''){
+  const row = document.createElement('div');
+  row.className = 'note-row';
+
+  const handle = document.createElement('span');
+  handle.className = 'note-handle';
+  handle.textContent = '\u2630';
+  handle.setAttribute('draggable', 'true');
+
+  const ta = document.createElement('textarea');
+  ta.className = 'note-text';
+  ta.value = text;
+  autoResize(ta);
+
+  const del = document.createElement('button');
+  del.className = 'note-delete btn danger';
+  del.textContent = '\u2715';
+
+  handle.addEventListener('dragstart', (e)=>{
+    draggingNote = row;
+    row.classList.add('dragging');
+    e.dataTransfer.setData('text/plain', '');
+  });
+  handle.addEventListener('dragend', ()=>{
+    row.classList.remove('dragging');
+    draggingNote = null;
+    saveNotes();
+  });
+  ta.addEventListener('input', ()=>{ autoResize(ta); saveNotes(); });
+  del.addEventListener('click', ()=>{ row.remove(); saveNotes(); });
+
+  row.append(handle, ta, del);
+  return row;
+}
+
+function addNote(text=''){
+  const row = createNote(text);
+  notesList.appendChild(row);
+  saveNotes();
+}
+
+addNoteBtn.addEventListener('click', ()=> addNote());
+clearNotesBtn.addEventListener('click', ()=>{
+  notesList.innerHTML = '';
+  localStorage.removeItem('notes');
+});
+
+notesList.addEventListener('dragover', (e)=>{
+  e.preventDefault();
+  if (!draggingNote) return;
+  const after = getDragAfterElement(e.clientY);
+  if (after == null) notesList.appendChild(draggingNote);
+  else notesList.insertBefore(draggingNote, after);
+});
+notesList.addEventListener('drop', (e)=> e.preventDefault());
+
+function getDragAfterElement(y){
+  const els = [...notesList.querySelectorAll('.note-row:not(.dragging)')];
+  return els.reduce((closest, child)=>{
+    const box = child.getBoundingClientRect();
+    const offset = y - box.top - box.height / 2;
+    if (offset < 0 && offset > closest.offset) return { offset, element: child };
+    else return closest;
+  }, { offset: Number.NEGATIVE_INFINITY, element: null }).element;
+}
+
+function loadNotes(){
+  try {
+    const data = JSON.parse(localStorage.getItem('notes') || '[]');
+    data.forEach(t => addNote(t));
+  } catch (e) { /* ignore */ }
+}
+
+loadNotes();

--- a/index.html
+++ b/index.html
@@ -13,10 +13,11 @@
 <body>
   <header>
     <h1>D&D 5e Toolkit</h1>
-    <p>DPR Calculator and Initiative Tracker</p>
+    <p>DPR Calculator, Initiative Tracker, and Notes</p>
     <nav class="tabs">
       <button class="tab active" data-tab="dpr">DPR Calculator</button>
       <button class="tab" data-tab="init">Initiative Tracker</button>
+      <button class="tab" data-tab="notes">Notes</button>
     </nav>
     <div class="tabspacer"></div>
   </header>
@@ -201,8 +202,19 @@
     </div>
   </section>
 
+  <!-- Notes -->
+  <section class="page" id="page-notes">
+    <div class="notes-wrap">
+      <h2>Notes</h2>
+      <div class="row notes-controls">
+        <button class="btn" id="addNote">Add Note</button>
+        <button class="btn danger" id="clearNotes">Clear All</button>
+      </div>
+      <div id="notesList" class="notes-list"></div>
+    </div>
+  </section>
+
   <script>
-    const ver = new Date(document.lastModified).getTime();
     document.write(`<script src="app.js?v=${ver}"><\/script>`);
   </script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -82,3 +82,14 @@ input::placeholder{color:#677086}
   .init-header{grid-template-columns:40px 1.2fr 80px 100px 120px 1fr 1fr}
   .init-row{grid-template-columns:40px 1.2fr 80px 100px 120px 1fr 1fr}
 }
+
+/* Notes */
+.notes-wrap{padding:18px;max-width:800px;margin:0 auto}
+.notes-controls{margin-bottom:10px}
+.notes-list{display:flex;flex-direction:column;gap:8px}
+.note-row{display:flex;gap:8px;align-items:flex-start;background:#0f1320;border:1px solid var(--line);border-radius:10px;padding:8px}
+.note-handle{cursor:grab;padding:4px;font-size:16px;user-select:none}
+.note-text{flex:1;resize:none;background:none;border:none;color:var(--ink);font:inherit;line-height:1.4;min-height:40px}
+.note-text:focus{outline:none}
+.note-delete{align-self:flex-start;padding:4px 8px}
+.note-row.dragging{opacity:.5}


### PR DESCRIPTION
## Summary
- Add Notes tab and page with add and clear buttons
- Implement draggable, auto-resizing note rows stored in localStorage
- Style Notes interface for inline editing and drag handles
- Fix app script loading by removing duplicate version variable

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fb1924ca4832998dedbda2803100b