### PR TITLE
Persist DPR and initiative data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and various dice utilities.
 - **Weapon Masteries** – toggle Cleave, Graze, and Vex effects in attack simulations.
 - **Initiative Tracker** – manage combat order with conditions and auto‑sorting.
 - **Dice Utilities** – roll expressions, compute averages and simulate advantage modes.
+- **Local Persistence** – DPR calculator, initiative tracker, and notes survive page refreshes via local storage.
 
 Open `index.html` in a modern browser to use the app. All logic runs locally in
 `app.js` with styling from `styles.css`.


### PR DESCRIPTION
## Summary
- Save DPR calculator state (builder fields, round entries, options) to localStorage and restore on load
- Save initiative tracker participants, turn info, and round counter to localStorage
- Clear actions now remove corresponding localStorage entries
- Note local persistence in README

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689fb539d8bc8329b2cd5da45fcdf9b1