### PR TITLE
feat: add attack roller tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@
 const tabButtons = document.querySelectorAll('.tab');
 const pages = {
   dpr: document.getElementById('page-dpr'),
+  roller: document.getElementById('page-roller'),
   init: document.getElementById('page-init'),
   notes: document.getElementById('page-notes')
 };
@@ -108,11 +109,12 @@ function rollDiceExprDetailed(expr){
   return { total, parts };
 }
 /** Detailed d20 roll with all individual dice kept. */
-function rollD20ModeDetailed(mode){
+function rollD20ModeDetailed(mode, halfling=false){
+  const rollOnce=()=>{ let r=rollDie(20); if(halfling && r===1) r=rollDie(20); return r; };
   const rolls=[];
-  const a=rollDie(20); rolls.push(a);
-  if (mode==='adv' || mode==='dis'){ const b=rollDie(20); rolls.push(b); }
-  if (mode==='elven'){ const b=rollDie(20), c=rollDie(20); rolls.push(b,c); }
+  const a=rollOnce(); rolls.push(a);
+  if (mode==='adv' || mode==='dis'){ const b=rollOnce(); rolls.push(b); }
+  if (mode==='elven'){ const b=rollOnce(), c=rollOnce(); rolls.push(b,c); }
   let result;
   if (mode==='adv') result=Math.max(rolls[0],rolls[1]);
   else if (mode==='dis') result=Math.min(rolls[0],rolls[1]);
@@ -362,6 +364,7 @@ function attackCard(idx,item){
     <div class="row" style="margin-top:4px;gap:8px;">
       <button class="btn" data-action="recalc">Recalc</button>
       <button class="btn" data-action="duplicate">Duplicate</button>
+      <button class="btn" data-action="toRoller">To Roller</button>
       <button class="btn danger" data-action="remove">Remove</button>
     </div>
     <div class="foot small mono" data-show="detail"></div>
@@ -434,6 +437,8 @@ function renderRound(){
     card.querySelector('[data-action="remove"]').addEventListener("click",()=>{ round.splice(idx,1); if (gwmProfileIndex===idx) gwmProfileIndex=-1; if (gwmProfileIndex>idx) gwmProfileIndex--; if (cleaveProfileIndex===idx) cleaveProfileIndex=-1; if (cleaveProfileIndex>idx) cleaveProfileIndex--; renderRound(); recomputeRound(); });
     const dupBtn = card.querySelector('[data-action="duplicate"]');
     if (dupBtn){ dupBtn.addEventListener("click",()=>{ const copy = JSON.parse(JSON.stringify(round[idx])); round.splice(idx+1,0,copy); if (gwmProfileIndex>idx) gwmProfileIndex++; if (cleaveProfileIndex>idx) cleaveProfileIndex++; renderRound(); recomputeRound(); }); }
+    const toRollBtn = card.querySelector('[data-action="toRoller"]');
+    if (toRollBtn){ toRollBtn.addEventListener("click",()=>{ sendAttackToRoller(round[idx]); }); }
     const recalcBtn = card.querySelector('[data-action="recalc"]');
     if (recalcBtn){ recalcBtn.addEventListener("click",()=>{ recalcCard(card, round[idx]); recomputeRound(); }); }
     recalcCard(card, round[idx]);
@@ -689,6 +694,83 @@ document.getElementById("calcAvg").addEventListener("click", ()=>{
   el.addEventListener('change', saveDPRState);
 });
 (function initDPR(){ loadDPRState(); showOne(); renderRound(); const el=document.getElementById("breakdown"); el.style.display="none"; document.getElementById("toggleBreakdown").textContent="Show breakdown"; })();
+
+/************ Attack Roller ************/
+const rollerAttacks = [];
+let vexAdv = false;
+function saveRollerState(){ try{ localStorage.setItem('rollerState', JSON.stringify(rollerAttacks)); }catch{} }
+function loadRollerState(){ try{ const data = JSON.parse(localStorage.getItem('rollerState')); if(Array.isArray(data)) rollerAttacks.splice(0,rollerAttacks.length,...data); }catch{} }
+function rollerCard(idx,item){ return `
+  <div class="card" data-idx="${idx}" style="margin-bottom:10px;">
+    <div class="grid">
+      <div class="col2"><label>+Hit</label><input type="number" data-field="atk" value="${item.atk}"/></div>
+      <div class="col2"><label>AC</label><input type="number" data-field="ac" value="${item.ac}"/></div>
+      <div class="col3"><label>Roll Mode</label><select data-field="mode"><option value="normal" ${item.mode==='normal'?'selected':''}>Normal</option><option value="adv" ${item.mode==='adv'?'selected':''}>Advantage</option><option value="elven" ${item.mode==='elven'?'selected':''}>Elven Accuracy</option><option value="dis" ${item.mode==='dis'?'selected':''}>Disadvantage</option></select></div>
+      <div class="col2"><label>Halfling</label><select data-field="halfling"><option value="false" ${!item.halfling?'selected':''}>Off</option><option value="true" ${item.halfling?'selected':''}>On</option></select></div>
+      <div class="col1"><label>Crit ≥</label><select data-field="crit"><option value="20" ${item.crit===20?'selected':''}>20</option><option value="19" ${item.crit===19?'selected':''}>19</option><option value="18" ${item.crit===18?'selected':''}>18</option></select></div>
+      <div class="col12"><label>Damage</label><input type="text" class="mono" data-field="dmg" value="${item.dmg}"/></div>
+      <div class="col4"><label>Crit Bonus Dice</label><input type="text" class="mono" data-field="critBonusDice" value="${item.critBonusDice||''}"/></div>
+      <div class="col2"><label>Dice double?</label><select data-field="critBonusDiceDouble"><option value="false" ${!item.critBonusDiceDouble?'selected':''}>No</option><option value="true" ${item.critBonusDiceDouble?'selected':''}>Yes</option></select></div>
+      <div class="col2"><label>Crit Bonus Flat</label><input type="number" data-field="critBonusFlat" value="${item.critBonusFlat||0}"/></div>
+      <div class="col2"><label>Graze</label><select data-field="graze"><option value="false" ${!item.graze?'selected':''}>Off</option><option value="true" ${item.graze?'selected':''}>On</option></select></div>
+      <div class="col2"><label>Ability Mod</label><input type="number" data-field="abilityMod" value="${item.abilityMod||0}"/></div>
+      <div class="col2"><label>Vex</label><select data-field="vex"><option value="false" ${!item.vex?'selected':''}>Off</option><option value="true" ${item.vex?'selected':''}>On</option></select></div>
+      <div class="col2"><label>Cleave</label><select data-field="cleave"><option value="false" ${!item.cleave?'selected':''}>Off</option><option value="true" ${item.cleave?'selected':''}>On</option></select></div>
+    </div>
+    <div class="row" style="margin-top:8px;gap:8px;">
+      <button class="btn" data-act="roll">Roll</button>
+      <button class="btn danger" data-act="remove">Remove</button>
+    </div>
+    <div class="foot small mono" data-show="result"></div>
+  </div>`; }
+function renderRoller(){
+  const root=document.getElementById('rollerList');
+  root.innerHTML=rollerAttacks.map((it,idx)=>rollerCard(idx,it)).join('');
+  root.querySelectorAll('.card').forEach(card=>{
+    const idx=Number(card.getAttribute('data-idx'));
+    const obj=rollerAttacks[idx];
+    card.querySelectorAll('[data-field]').forEach(inp=>{
+      inp.addEventListener('input',()=>{
+        const field=inp.getAttribute('data-field');
+        let val=inp.value;
+        if(['atk','ac','crit','critBonusFlat','abilityMod'].includes(field)) val=Number(val||0);
+        if(['halfling','graze','vex','cleave','critBonusDiceDouble'].includes(field)) val=(val==='true');
+        obj[field]=val; saveRollerState();
+      });
+    });
+    card.querySelector('[data-act="roll"]').addEventListener('click',()=>{ rollAttack(obj,card); });
+    card.querySelector('[data-act="remove"]').addEventListener('click',()=>{ rollerAttacks.splice(idx,1); renderRoller(); saveRollerState(); });
+  });
+  saveRollerState();
+}
+function fmtRoll(r){ return r.parts.map(p=>p.type==='flat'?p.value:p.rolls.join('+')).join('+')+"="+r.total; }
+function rollAttack(att,card){
+  const mode=applyVexMode(att.mode, vexAdv);
+  vexAdv=false;
+  const d20=rollD20ModeDetailed(mode, att.halfling);
+  const total=d20.result+att.atk;
+  let hit=false,crit=false;
+  if(d20.result===1) hit=false;
+  else if(d20.result===20){ hit=true; crit=true; }
+  else{ hit=(d20.result+att.atk)>=att.ac; if(hit && d20.result>=att.crit) crit=true; }
+  let dmgTotal=0, detail=[];
+  if(hit){
+    const base=rollDiceExprDetailed(att.dmg); dmgTotal+=base.total; detail.push(`base(${fmtRoll(base)})`);
+    if(crit){
+      const extra=rollDiceExprDetailed(att.dmg); dmgTotal+=extra.total; detail.push(`critExtra(${fmtRoll(extra)})`);
+      if(att.critBonusDice){ const b1=rollDiceExprDetailed(att.critBonusDice); dmgTotal+=b1.total; detail.push(`critBonus(${fmtRoll(b1)})`); if(att.critBonusDiceDouble){ const b2=rollDiceExprDetailed(att.critBonusDice); dmgTotal+=b2.total; detail.push(`critBonus2(${fmtRoll(b2)})`); } }
+      if(att.critBonusFlat){ dmgTotal+=Number(att.critBonusFlat); detail.push(`+${att.critBonusFlat}`); }
+    }
+    if(att.vex) vexAdv=true;
+  } else if(att.graze){ const mod=Number(att.abilityMod||0); dmgTotal+=mod; detail.push(`graze ${mod}`); }
+  const parts=`d20[${d20.rolls.join(',')}] => ${d20.result} + ${att.atk} = ${total}`;
+  const res=`${parts} vs AC ${att.ac} ⇒ ${crit?'CRIT':hit?'hit':'miss'}${dmgTotal?`, dmg ${dmgTotal} (${detail.join(' + ')})`:''}${att.cleave && hit?' | Cleave available':''}${att.vex && hit?' | Vex: next attack adv':''}`;
+  card.querySelector('[data-show="result"]').textContent=res;
+}
+document.getElementById('rollerAdd').addEventListener('click',()=>{ rollerAttacks.push({atk:5,ac:15,mode:'normal',halfling:false,crit:20,dmg:'1d8+3',critBonusDice:'',critBonusFlat:0,critBonusDiceDouble:false,graze:false,abilityMod:0,vex:false,cleave:false}); renderRoller(); });
+document.getElementById('rollerClear').addEventListener('click',()=>{ rollerAttacks.splice(0,rollerAttacks.length); renderRoller(); saveRollerState(); });
+function sendAttackToRoller(atk){ rollerAttacks.push({ atk:atk.atk, ac:atk.ac, mode:atk.mode, halfling:atk.halfling, crit:atk.crit, dmg:atk.dmg, critBonusDice:atk.critBonusDice||'', critBonusFlat:atk.critBonusFlat||0, critBonusDiceDouble:atk.critBonusDiceDouble||false, graze:atk.graze||false, abilityMod:atk.abilityMod||0, vex:atk.vex||false, cleave:atk.cleave||false }); renderRoller(); }
+(function initRoller(){ loadRollerState(); renderRoller(); })();
 
 /************ Initiative Tracker ************/
 let initList = [];  // [{id, name, init, bonusExpr, dexMod, advMode, notes, conditions:[{name,duration}], initTooltip, showCond:false}]

--- a/index.html
+++ b/index.html
@@ -13,9 +13,10 @@
 <body>
   <header>
     <h1>D&D 5e Toolkit</h1>
-    <p>DPR Calculator, Initiative Tracker, and Notes</p>
+    <p>DPR Calculator, Attack Roller, Initiative Tracker, and Notes</p>
     <nav class="tabs">
       <button class="tab active" data-tab="dpr">DPR Calculator</button>
+      <button class="tab" data-tab="roller">Attack Roller</button>
       <button class="tab" data-tab="init">Initiative Tracker</button>
       <button class="tab" data-tab="notes">Notes</button>
     </nav>
@@ -142,6 +143,20 @@
         <div id="avgBreak" class="foot small mono"></div>
       </section>
     </main>
+  </section>
+
+  <!-- Attack Roller -->
+  <section class="page" id="page-roller">
+    <div class="roller-wrap">
+      <div class="card">
+        <h2>Attack Roller</h2>
+        <div class="row" style="margin-bottom:10px;">
+          <button class="btn" id="rollerAdd">+ Add Attack</button>
+          <button class="btn danger" id="rollerClear">Clear All</button>
+        </div>
+        <div id="rollerList"></div>
+      </div>
+    </div>
   </section>
 
   <!-- Initiative Tracker -->

--- a/styles.css
+++ b/styles.css
@@ -85,6 +85,7 @@ input::placeholder{color:#677086}
 
 /* Notes */
 .notes-wrap{padding:18px;max-width:800px;margin:0 auto}
+.roller-wrap{padding:18px;max-width:800px;margin:0 auto}
 .notes-controls{margin-bottom:10px}
 .notes-list{display:flex;flex-direction:column;gap:8px}
 .note-row{display:flex;gap:8px;align-items:flex-start;background:#0f1320;border:1px solid var(--line);border-radius:10px;padding:8px}


### PR DESCRIPTION
## Summary
- add Attack Roller tab to create, roll, and persist attacks
- support clearing attacks individually or all at once
- send attacks from DPR tab to Attack Roller with triggered effects

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689fc160e12c8329a01a79bba435b2ab