### PR TITLE
feat: enhance attack roller and add spell support

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,7 @@
         <h2>Attack Roller</h2>
         <div class="row" style="margin-bottom:10px;">
           <button class="btn" id="rollerAdd">+ Add Attack</button>
+          <button class="btn" id="rollerAddSpell">+ Add Spell</button>
           <button class="btn danger" id="rollerClear">Clear All</button>
         </div>
         <div id="rollerList"></div>

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,7 @@ input::placeholder{color:#677086}
 .stat{display:grid;gap:2px}
 .stat b{font-size:18px}
 .small{font-size:12px;color:var(--muted)}
+.roll-main{font-size:16px;font-weight:600;color:var(--ink)}
 .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace}
 .tag{padding:2px 8px;border-radius:6px;border:1px solid var(--line);background:#0f1320;color:var(--ink)}
 .ok{color:var(--good)} .warn{color:var(--warn)} .bad{color:var(--bad)}


### PR DESCRIPTION
## Summary
- remove AC requirement from attack roller and stylize results for quick play
- add spell entries and rolling logic to the attack roller
- allow spells to be sent from round composer to the attack roller

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc87c163c832984585fd9d0889fbf