### PR TITLE
Add attack trigger indicators to roller

### DIFF
--- a/app.js
+++ b/app.js
@@ -708,17 +708,30 @@ function saveRollerState(){ try{ localStorage.setItem('rollerState', JSON.string
 function loadRollerState(){
   try{
     const data = JSON.parse(localStorage.getItem('rollerState'));
-    if(Array.isArray(data)) rollerItems.splice(0,rollerItems.length,...data.map(it=>it.kind?it:Object.assign({kind:'attack'},it)));
+    if(Array.isArray(data)) rollerItems.splice(0,rollerItems.length,...data.map(it=>{
+      if(!it.kind) it = Object.assign({kind:'attack'},it);
+      if(it.kind==='attack'){
+        if(it.ac===undefined) it.ac=15;
+        it.vex=!!it.vex; it.heavy=!!it.heavy; it.graze=!!it.graze;
+        if(it.abilityMod===undefined) it.abilityMod=0;
+      }
+      return it;
+    }));
   }catch{}
 }
 function rollerAttackCard(idx,item){ return `
   <div class="card" data-idx="${idx}" data-kind="attack" style="margin-bottom:10px;">
     <div class="grid">
       <div class="col2"><label>+Hit</label><input type="number" data-field="atk" value="${item.atk}"/></div>
+      <div class="col2"><label>Target AC</label><input type="number" data-field="ac" value="${item.ac!==undefined?item.ac:15}"/></div>
       <div class="col3"><label>Roll Mode</label><select data-field="mode"><option value="normal" ${item.mode==='normal'?'selected':''}>Normal</option><option value="adv" ${item.mode==='adv'?'selected':''}>Advantage</option><option value="elven" ${item.mode==='elven'?'selected':''}>Elven Accuracy</option><option value="dis" ${item.mode==='dis'?'selected':''}>Disadvantage</option></select></div>
-      <div class="col2"><label>Halfling</label><select data-field="halfling"><option value="false" ${!item.halfling?'selected':''}>Off</option><option value="true" ${item.halfling?'selected':''}>On</option></select></div>
-      <div class="col1"><label>Crit ≥</label><select data-field="crit"><option value="20" ${item.crit===20?'selected':''}>20</option><option value="19" ${item.crit===19?'selected':''}>19</option><option value="18" ${item.crit===18?'selected':''}>18</option></select></div>
-      <div class="col12"><label>Damage</label><input type="text" class="mono" data-field="dmg" value="${item.dmg}"/></div>
+      <div class="col1"><label>Halfling</label><select data-field="halfling"><option value="false" ${!item.halfling?'selected':''}>Off</option><option value="true" ${item.halfling?'selected':''}>On</option></select></div>
+      <div class="col1"><label>Crit ≥</label><select data-field="crit" class="crit-select"><option value="20" ${item.crit===20?'selected':''}>20</option><option value="19" ${item.crit===19?'selected':''}>19</option><option value="18" ${item.crit===18?'selected':''}>18</option></select></div>
+      <div class="col1"><label>Vex</label><select data-field="vex"><option value="false" ${!item.vex?'selected':''}>Off</option><option value="true" ${item.vex?'selected':''}>On</option></select></div>
+      <div class="col1"><label>GWM?</label><select data-field="heavy"><option value="false" ${!item.heavy?'selected':''}>Off</option><option value="true" ${item.heavy?'selected':''}>On</option></select></div>
+      <div class="col1"><label>Graze</label><select data-field="graze"><option value="false" ${!item.graze?'selected':''}>Off</option><option value="true" ${item.graze?'selected':''}>On</option></select></div>
+      <div class="col3"><label>Ability Mod (Graze)</label><input type="number" data-field="abilityMod" value="${item.abilityMod||0}"/></div>
+      <div class="col9"><label>Damage</label><input type="text" class="mono" data-field="dmg" value="${item.dmg}"/></div>
       <div class="col4"><label>Crit Bonus Dice</label><input type="text" class="mono" data-field="critBonusDice" value="${item.critBonusDice||''}"/></div>
       <div class="col2"><label>Dice double?</label><select data-field="critBonusDiceDouble"><option value="false" ${!item.critBonusDiceDouble?'selected':''}>No</option><option value="true" ${item.critBonusDiceDouble?'selected':''}>Yes</option></select></div>
       <div class="col2"><label>Crit Bonus Flat</label><input type="number" data-field="critBonusFlat" value="${item.critBonusFlat||0}"/></div>
@@ -755,9 +768,9 @@ function renderRoller(){
       inp.addEventListener('input',()=>{
         const field=inp.getAttribute('data-field');
         let val=inp.value;
-        if(kind==='attack' && ['atk','crit','critBonusFlat'].includes(field)) val=Number(val||0);
+        if(kind==='attack' && ['atk','crit','critBonusFlat','ac','abilityMod'].includes(field)) val=Number(val||0);
         if(kind==='spell' && ['dc','saveBonus'].includes(field)) val=Number(val||0);
-        if(kind==='attack' && ['halfling','critBonusDiceDouble'].includes(field)) val=(val==='true');
+        if(kind==='attack' && ['halfling','critBonusDiceDouble','vex','graze','heavy'].includes(field)) val=(val==='true');
         obj[field]=val; saveRollerState();
       });
     });
@@ -771,15 +784,34 @@ function rollAttack(att,card){
   const d20=rollD20ModeDetailed(att.mode, att.halfling);
   const total=d20.result+att.atk;
   const crit=(d20.result>=att.crit);
+  let hit;
+  if(d20.result===1) hit=false;
+  else if(d20.result===20) hit=true;
+  else hit=(total>=att.ac);
+
   let dmgTotal=0, detail=[];
-  const base=rollDiceExprDetailed(att.dmg); dmgTotal+=base.total; detail.push(`base(${fmtRoll(base)})`);
-  if(crit){
-    const extra=rollDiceExprDetailed(att.dmg); dmgTotal+=extra.total; detail.push(`critExtra(${fmtRoll(extra)})`);
-    if(att.critBonusDice){ const b1=rollDiceExprDetailed(att.critBonusDice); dmgTotal+=b1.total; detail.push(`critBonus(${fmtRoll(b1)})`); if(att.critBonusDiceDouble){ const b2=rollDiceExprDetailed(att.critBonusDice); dmgTotal+=b2.total; detail.push(`critBonus2(${fmtRoll(b2)})`); } }
-    if(att.critBonusFlat){ dmgTotal+=Number(att.critBonusFlat); detail.push(`+${att.critBonusFlat}`); }
+  if(hit){
+    const base=rollDiceExprDetailed(att.dmg); dmgTotal+=base.total; detail.push(`base(${fmtRoll(base)})`);
+    if(crit){
+      const extra=rollDiceExprDetailed(att.dmg); dmgTotal+=extra.total; detail.push(`critExtra(${fmtRoll(extra)})`);
+      if(att.critBonusDice){ const b1=rollDiceExprDetailed(att.critBonusDice); dmgTotal+=b1.total; detail.push(`critBonus(${fmtRoll(b1)})`); if(att.critBonusDiceDouble){ const b2=rollDiceExprDetailed(att.critBonusDice); dmgTotal+=b2.total; detail.push(`critBonus2(${fmtRoll(b2)})`); } }
+      if(att.critBonusFlat){ dmgTotal+=Number(att.critBonusFlat); detail.push(`+${att.critBonusFlat}`); }
+    }
+  } else {
+    if(att.graze){
+      dmgTotal += Number(att.abilityMod||0);
+      detail.push(`graze(${att.abilityMod||0})`);
+    } else {
+      detail.push('miss');
+    }
   }
-  const parts=`d20[${d20.rolls.join(',')}] + ${att.atk} = ${total}`;
-  const res=`<div><span class="roll-main">To Hit: ${total}${crit?' (CRIT)':''}</span> <span class="small">(${parts})</span></div><div><span class="roll-main">Damage: ${dmgTotal}</span> <span class="small">(${detail.join(' + ')})</span></div>`;
+  const parts=`d20[${d20.rolls.join(',')}] + ${att.atk} = ${total} vs AC ${att.ac}`;
+  const tags=[];
+  if(hit && att.vex) tags.push('<span class="tag">Vex ready</span>');
+  if(crit && att.heavy) tags.push('<span class="tag">GWM ready</span>');
+  if(!hit && att.graze) tags.push('<span class="tag">Graze</span>');
+  const tagHtml = tags.length? `<div class="row" style="gap:4px;">${tags.join(' ')}</div>` : '';
+  const res=`<div class="row between"><div><span class="roll-main">To Hit: ${total}${crit?' (CRIT)':''}${hit?' (HIT)':' (MISS)'}</span> <span class="small">(${parts})</span></div>${tagHtml}</div><div><span class="roll-main">Damage: ${dmgTotal}</span> <span class="small">(${detail.join(' + ')})</span></div>`;
   card.querySelector('[data-show="result"]').innerHTML=res;
 }
 function rollSpell(sp,card){
@@ -796,10 +828,10 @@ function rollSpell(sp,card){
   const res=`<div><span class="roll-main">Save: ${total} ${success?'(success)':'(fail)'}</span> <span class="small">(${parts})</span></div><div><span class="roll-main">Damage: ${dmgTotal}</span> <span class="small">(${detail.join(' + ')})</span></div>`;
   card.querySelector('[data-show="result"]').innerHTML=res;
 }
-document.getElementById('rollerAdd').addEventListener('click',()=>{ rollerItems.push({kind:'attack',atk:5,mode:'normal',halfling:false,crit:20,dmg:'1d8+3',critBonusDice:'',critBonusFlat:0,critBonusDiceDouble:false}); renderRoller(); });
+document.getElementById('rollerAdd').addEventListener('click',()=>{ rollerItems.push({kind:'attack',atk:5,ac:15,mode:'normal',halfling:false,crit:20,dmg:'1d8+3',critBonusDice:'',critBonusFlat:0,critBonusDiceDouble:false,vex:false,heavy:false,graze:false,abilityMod:3}); renderRoller(); });
 document.getElementById('rollerAddSpell').addEventListener('click',()=>{ rollerItems.push({kind:'spell',dc:15,saveBonus:3,saveMode:'normal',successRule:'half',dmg:'3d8'}); renderRoller(); });
 document.getElementById('rollerClear').addEventListener('click',()=>{ rollerItems.splice(0,rollerItems.length); renderRoller(); saveRollerState(); });
-function sendAttackToRoller(atk){ rollerItems.push({ kind:'attack', atk:atk.atk, mode:atk.mode, halfling:atk.halfling, crit:atk.crit, dmg:atk.dmg, critBonusDice:atk.critBonusDice||'', critBonusFlat:atk.critBonusFlat||0, critBonusDiceDouble:atk.critBonusDiceDouble||false }); renderRoller(); }
+function sendAttackToRoller(atk){ rollerItems.push({ kind:'attack', atk:atk.atk, ac:atk.ac, mode:atk.mode, halfling:atk.halfling, crit:atk.crit, dmg:atk.dmg, critBonusDice:atk.critBonusDice||'', critBonusFlat:atk.critBonusFlat||0, critBonusDiceDouble:atk.critBonusDiceDouble||false, vex:atk.vex||false, heavy:atk.heavy||false, graze:atk.graze||false, abilityMod:atk.abilityMod||0 }); renderRoller(); }
 function sendSpellToRoller(sp){ rollerItems.push({ kind:'spell', dc:sp.dc, saveBonus:sp.saveBonus, saveMode:sp.saveMode, successRule:sp.successRule, dmg:sp.dmg }); renderRoller(); }
 (function initRoller(){ loadRollerState(); renderRoller(); })();
 

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,7 @@ input::placeholder{color:#677086}
 .roll-main{font-size:16px;font-weight:600;color:var(--ink)}
 .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"Liberation Mono",monospace}
 .tag{padding:2px 8px;border-radius:6px;border:1px solid var(--line);background:#0f1320;color:var(--ink)}
+.crit-select{width:5ch}
 .ok{color:var(--good)} .warn{color:var(--warn)} .bad{color:var(--bad)}
 .foot{color:var(--muted);margin-top:6px}
 .section-title{font-weight:600;font-size:12px;color:#9fb0c7;text-transform:uppercase;letter-spacing:.08em;margin:10px 0 2px}


### PR DESCRIPTION
## Summary
- Add Vex, GWM and Graze toggles to attack roller
- Show trigger tags after rolls based on hit, crit or miss
- Widen crit dropdown for readability

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689fcc1555608329a11ff783d904d93c