### PR TITLE
Add D&D condition quick reference tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,8 @@ const pages = {
   dpr: document.getElementById('page-dpr'),
   roller: document.getElementById('page-roller'),
   init: document.getElementById('page-init'),
-  notes: document.getElementById('page-notes')
+  notes: document.getElementById('page-notes'),
+  quickref: document.getElementById('page-quickref')
 };
 tabButtons.forEach(btn=>{
   btn.addEventListener('click', ()=>{
@@ -20,6 +21,17 @@ tabButtons.forEach(btn=>{
     pages[btn.dataset.tab].classList.add('active');
   });
 });
+
+// Render quick reference conditions
+const condList = document.getElementById('conditionsList');
+if (condList && typeof CONDITIONS !== 'undefined') {
+  CONDITIONS.forEach(c => {
+    const tile = document.createElement('div');
+    tile.className = 'card cond-card';
+    tile.innerHTML = `<h3>${c.name}</h3><p>${c.desc}</p>`;
+    condList.appendChild(tile);
+  });
+}
 
 // ----- Dice Helpers -----
 // These utilities parse and roll common dice expressions.

--- a/conditions.js
+++ b/conditions.js
@@ -1,0 +1,63 @@
+const CONDITIONS = [
+  {
+    name: 'Blinded',
+    desc: "Can't see; fails checks requiring sight. Attacks against have advantage, and its attacks have disadvantage."
+  },
+  {
+    name: 'Charmed',
+    desc: "Can't attack charmer or target them with harmful abilities; charmer has advantage on social checks."
+  },
+  {
+    name: 'Deafened',
+    desc: "Can't hear and automatically fails checks that require hearing."
+  },
+  {
+    name: 'Frightened',
+    desc: "Disadvantage on checks and attacks while source of fear is in sight; can't willingly move closer to the source."
+  },
+  {
+    name: 'Grappled',
+    desc: "Speed becomes 0 and can't benefit from bonuses to speed. Ends if grappler is incapacitated or moved away."
+  },
+  {
+    name: 'Incapacitated',
+    desc: "Can't take actions or reactions."
+  },
+  {
+    name: 'Invisible',
+    desc: "Can't be seen; attacks against have disadvantage, and its attacks have advantage."
+  },
+  {
+    name: 'Paralyzed',
+    desc: "Incapacitated and can't move or speak; fails Str and Dex saves; attacks against have advantage; hits within 5 ft crit."
+  },
+  {
+    name: 'Petrified',
+    desc: "Turned to stone; incapacitated; attacks against have advantage; fails Str and Dex saves; resists all damage; immune to poison and disease."
+  },
+  {
+    name: 'Poisoned',
+    desc: "Disadvantage on attack rolls and ability checks."
+  },
+  {
+    name: 'Prone',
+    desc: "Only movement is crawl; attacks have disadvantage; attacks against have advantage within 5 ft, otherwise disadvantage."
+  },
+  {
+    name: 'Restrained',
+    desc: "Speed 0; attacks against have advantage; its attacks have disadvantage; disadvantage on Dex saves."
+  },
+  {
+    name: 'Stunned',
+    desc: "Incapacitated, can't move, can speak only falteringly; fails Str and Dex saves; attacks against have advantage."
+  },
+  {
+    name: 'Unconscious',
+    desc: "Unaware, drops and is prone, incapacitated; fails Str and Dex saves; attacks against have advantage; hits within 5 ft crit."
+  },
+  {
+    name: 'Exhaustion',
+    desc: 'Six levels with cumulative effects: 1) disadvantage on checks, 2) speed halved, 3) disadvantage on attacks and saves, 4) HP max halved, 5) speed 0, 6) death.'
+  }
+];
+

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       <button class="tab" data-tab="roller">Attack Roller</button>
       <button class="tab" data-tab="init">Initiative Tracker</button>
       <button class="tab" data-tab="notes">Notes</button>
+      <button class="tab" data-tab="quickref">Quick Reference</button>
     </nav>
     <div class="tabspacer"></div>
   </header>
@@ -230,7 +231,16 @@
     </div>
   </section>
 
+  <!-- Quick Reference -->
+  <section class="page" id="page-quickref">
+    <div class="quickref-wrap">
+      <h2>Quick Reference</h2>
+      <div id="conditionsList" class="cond-grid"></div>
+    </div>
+  </section>
+
   <script>
+    document.write(`<script src="conditions.js?v=${ver}"><\/script>`);
     document.write(`<script src="app.js?v=${ver}"><\/script>`);
   </script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,12 @@ input::placeholder{color:#677086}
 .cond-toggle .cond-btn.active{background:#2b4a69;border-color:#74a7d8;color:#e8f6ff}
 .popover{position:absolute;background:#0f1320;border:1px solid var(--line);border-radius:10px;padding:10px;box-shadow:0 8px 24px rgba(0,0,0,.35);z-index:10;min-width:340px}
 
+/* Quick Reference */
+.quickref-wrap{padding:18px;max-width:1000px;margin:0 auto}
+.cond-grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fill,minmax(200px,1fr))}
+.cond-card h3{margin:0 0 6px;font-size:16px}
+.cond-card p{margin:0;color:var(--muted);font-size:13px}
+
 /* Responsive */
 @media (max-width: 1100px){ main{grid-template-columns:1fr} }
 @media (max-width: 1200px){


### PR DESCRIPTION
## Summary
- Add "Quick Reference" tab with tiles for common D&D 5e conditions
- Store condition descriptions in a static `CONDITIONS` list for easy editing
- Include basic styling for the new reference grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a060dd2734832986836aaa77ff4385